### PR TITLE
bugfix: update gems

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -2,34 +2,34 @@ PATH
   remote: .
   specs:
     vagrant-ssh-config (1.0.1)
-      net-ssh (~> 3.0.2)
+      net-ssh (>= 3.0.2)
 
 GEM
   remote: https://rubygems.org/
   specs:
-    ast (2.3.0)
+    ast (2.4.0)
     diff-lcs (1.3)
-    net-ssh (3.0.2)
-    parallel (1.12.0)
-    parser (2.4.0.2)
-      ast (~> 2.3)
-    powerpack (0.1.1)
+    net-ssh (5.0.2)
+    parallel (1.12.1)
+    parser (2.5.1.2)
+      ast (~> 2.4.0)
+    powerpack (0.1.2)
     rainbow (2.2.2)
       rake
     rake (10.5.0)
-    rspec (3.7.0)
-      rspec-core (~> 3.7.0)
-      rspec-expectations (~> 3.7.0)
-      rspec-mocks (~> 3.7.0)
-    rspec-core (3.7.0)
-      rspec-support (~> 3.7.0)
-    rspec-expectations (3.7.0)
+    rspec (3.8.0)
+      rspec-core (~> 3.8.0)
+      rspec-expectations (~> 3.8.0)
+      rspec-mocks (~> 3.8.0)
+    rspec-core (3.8.0)
+      rspec-support (~> 3.8.0)
+    rspec-expectations (3.8.2)
       diff-lcs (>= 1.2.0, < 2.0)
-      rspec-support (~> 3.7.0)
-    rspec-mocks (3.7.0)
+      rspec-support (~> 3.8.0)
+    rspec-mocks (3.8.0)
       diff-lcs (>= 1.2.0, < 2.0)
-      rspec-support (~> 3.7.0)
-    rspec-support (3.7.0)
+      rspec-support (~> 3.8.0)
+    rspec-support (3.8.0)
     rubocop (0.51.0)
       parallel (~> 1.10)
       parser (>= 2.3.3.1, < 3.0)
@@ -37,8 +37,8 @@ GEM
       rainbow (>= 2.2.2, < 3.0)
       ruby-progressbar (~> 1.7)
       unicode-display_width (~> 1.0, >= 1.0.1)
-    ruby-progressbar (1.9.0)
-    unicode-display_width (1.3.0)
+    ruby-progressbar (1.10.0)
+    unicode-display_width (1.4.0)
 
 PLATFORMS
   ruby
@@ -51,4 +51,4 @@ DEPENDENCIES
   vagrant-ssh-config!
 
 BUNDLED WITH
-   1.16.0
+   1.16.3

--- a/vagrant-ssh-config.gemspec
+++ b/vagrant-ssh-config.gemspec
@@ -32,7 +32,7 @@ Gem::Specification.new do |spec|
   spec.executables   = spec.files.grep(%r{^exe/}) { |f| File.basename(f) }
   spec.require_paths = ["lib"]
 
-  spec.add_runtime_dependency "net-ssh", "~> 3.0.2"
+  spec.add_runtime_dependency "net-ssh", ">= 3.0.2"
 
   spec.add_development_dependency "bundler", "~> 1.16"
   spec.add_development_dependency "rake", "~> 10.0"


### PR DESCRIPTION
net-ssh is too old and blocks more recent net-ssh in other repositories